### PR TITLE
fix: correct build->dockerfile case

### DIFF
--- a/compose/v3/types.dhall
+++ b/compose/v3/types.dhall
@@ -12,7 +12,7 @@ let Build
     = < String :
           Text
       | Object :
-          { context : Text, Dockerfile : Text, args : ListOrDict }
+          { context : Text, dockerfile : Text, args : ListOrDict }
       >
 
 let StringOrList : Type = < String : Text | List : List Text >


### PR DESCRIPTION
Corrects the case of `dockerfile` in the `build` options: https://docs.docker.com/compose/compose-file/#build