### PR TITLE
Fix: dockerfile should be all lowercase

### DIFF
--- a/compose/v3/types.dhall
+++ b/compose/v3/types.dhall
@@ -12,7 +12,7 @@ let Build
     = < String :
           Text
       | Object :
-          { context : Text, Dockerfile : Text, args : ListOrDict }
+          { context : Text, dockerfile : Text, args : ListOrDict }
       >
 
 let StringOrList : Type = < String : Text | List : List Text >


### PR DESCRIPTION
Hello. Thank you for `dhall-docker-compose`

I think I spot a minor issue. When using generated `docker-compose.yml` I get an error, lowercasing `Dockerfile` fixes it.

-----------------------
closing because of #1 
