### PR TITLE
Extend Build type with ssh property to support ssh forwarding configuration

### DIFF
--- a/compose/v3/types.dhall
+++ b/compose/v3/types.dhall
@@ -12,7 +12,12 @@ let ListOrDict
 let Build
     : Type
     = < String : Text
-      | Object : { context : Text, dockerfile : Text, args : ListOrDict }
+      | Object :
+          { context : Text
+          , dockerfile : Text
+          , args : ListOrDict
+          , ssh : ListOrDict
+          }
       >
 
 let StringOrList

--- a/example/docker-compose-deploy.dhall
+++ b/example/docker-compose-deploy.dhall
@@ -76,6 +76,22 @@ let reactService =
       , logging
       }
 
+let buildStubService =
+      Compose.Service::{
+      , build = Some
+          ( Compose.Build.Object
+              { dockerfile = "DockerfileStub"
+              , context = "."
+              , args =
+                  Compose.ListOrDict.List
+                    ([] : List (Optional Compose.StringOrNumber))
+              , ssh =
+                  Compose.ListOrDict.List
+                    [ Some (Compose.StringOrNumber.String "default") ]
+              }
+          )
+      }
+
 let toEntry =
       \(name : Text) ->
         { mapKey = name
@@ -101,6 +117,7 @@ let services
         , db = dbService
         , react = reactService
         , django = djangoService
+        , buildStub = buildStubService
         }
 
 in  Compose.Config::{ services = Some services, volumes = Some volumes }

--- a/example/docker-compose-deploy.yml
+++ b/example/docker-compose-deploy.yml
@@ -1,4 +1,11 @@
 services:
+  buildStub:
+    build:
+      args: []
+      context: '.'
+      dockerfile: DockerfileStub
+      ssh:
+        - default
   db:
     command:
       - "-c"


### PR DESCRIPTION
Extend Build type with ssh property to support ssh forwarding configuration, according to https://docs.docker.com/compose/compose-file/build/#ssh