### PR TITLE
 Add possibility to configure the "volume" attribute of a service in "long form"

### DIFF
--- a/compose/v3/defaults.dhall
+++ b/compose/v3/defaults.dhall
@@ -3,6 +3,16 @@ let Map =
 
 let types = ./types.dhall
 
+let ServiceVolumeLong =
+      { type = None Text
+      , source = None Text
+      , target = None Text
+      , read_only = None Bool
+      , bind = None { propagation : Optional Text }
+      , volume = None { nocopy : Optional Bool }
+      , tmpfs = None { size : Optional Text }
+      }
+
 let Service =
         { deploy = None types.Deploy
         , build = None types.Build
@@ -48,7 +58,7 @@ let Service =
         , ulimits = None (Map Text types.Ulimits)
         , user = None Text
         , userns_mode = None Text
-        , volumes = None (List Text)
+        , volumes = None (List types.ServiceVolume)
         , working_dir = None Text
         }
       : types.Service
@@ -78,4 +88,4 @@ let ComposeConfig =
         }
       : types.ComposeConfig
 
-in  { Service, Volume, ComposeConfig, Healthcheck }
+in  { ServiceVolumeLong, Service, Volume, ComposeConfig, Healthcheck }

--- a/compose/v3/package.dhall
+++ b/compose/v3/package.dhall
@@ -3,7 +3,9 @@ let defaults = ./defaults.dhall
 let types = ./types.dhall
 
 in    types
-    ⫽ { Service = { Type = types.Service, default = defaults.Service }
+    ⫽ { ServiceVolumeLong =
+        { Type = types.ServiceVolumeLong, default = defaults.ServiceVolumeLong }
+      , Service = { Type = types.Service, default = defaults.Service }
       , Volume = { Type = types.Volume, default = defaults.Volume }
       , Config =
         { Type = types.ComposeConfig, default = defaults.ComposeConfig }

--- a/compose/v3/types.dhall
+++ b/compose/v3/types.dhall
@@ -84,6 +84,21 @@ let Deploy
       , placement : { constraints : List Text }
       }
 
+let ServiceVolumeLong
+    : Type
+    = { type : Optional Text
+      , source : Optional Text
+      , target : Optional Text
+      , read_only : Optional Bool
+      , bind : Optional { propagation : Optional Text }
+      , volume : Optional { nocopy : Optional Bool }
+      , tmpfs : Optional { size : Optional Text }
+      }
+
+let ServiceVolume
+    : Type
+    = < Short : Text | Long : ServiceVolumeLong >
+
 let Service
     : Type
     = { deploy : Optional Deploy
@@ -130,7 +145,7 @@ let Service
       , ulimits : Optional (Map Text Ulimits)
       , user : Optional Text
       , userns_mode : Optional Text
-      , volumes : Optional (List Text)
+      , volumes : Optional (List ServiceVolume)
       , working_dir : Optional Text
       }
 
@@ -173,6 +188,8 @@ let ComposeConfig
 in  { ComposeConfig
     , Services
     , Service
+    , ServiceVolume
+    , ServiceVolumeLong
     , StringOrNumber
     , Deploy
     , Build

--- a/compose/v3/types.dhall
+++ b/compose/v3/types.dhall
@@ -48,6 +48,7 @@ let Logging
 let Networks
     : Type
     = < List : List Text
+      | Map : Map Text { name : Optional Text, external : Optional Bool }
       | Object :
           Optional
             { aliases : List Text, ipv4_address : Text, ipv6_address : Text }

--- a/example/docker-compose-deploy.dhall
+++ b/example/docker-compose-deploy.dhall
@@ -27,8 +27,8 @@ let nginxService =
       , image = Some "recipeyak/nginx:latest"
       , ports = Some [ Compose.StringOrNumber.String "80:80" ]
       , volumes = Some
-        [ "react-static-files:/var/app/dist"
-        , "django-static-files:/var/app/django/static"
+        [ Compose.ServiceVolume.Short "react-static-files:/var/app/dist"
+        , Compose.ServiceVolume.Short "django-static-files:/var/app/django/static"
         ]
       , logging
       , depends_on = Some [ "django", "react" ]
@@ -40,7 +40,7 @@ let djangoService =
       , image = Some "recipeyak/django:latest"
       , env_file = Some (Compose.StringOrList.List [ ".env-production" ])
       , command = Some (Compose.StringOrList.String "sh bootstrap-prod.sh")
-      , volumes = Some [ "django-static-files:/var/app/static-files" ]
+      , volumes = Some [ Compose.ServiceVolume.Short "django-static-files:/var/app/static-files" ]
       , logging
       , depends_on = Some [ "db" ]
       }
@@ -59,7 +59,7 @@ let dbService =
               ]
           )
       , ports = Some [ Compose.StringOrNumber.String "5432:5432" ]
-      , volumes = Some [ "pgdata:/var/lib/postgresql/data/" ]
+      , volumes = Some [ Compose.ServiceVolume.Short "pgdata:/var/lib/postgresql/data/" ]
       , logging
       , healthcheck = Some Compose.Healthcheck::{
         , test = Some (Compose.StringOrList.String "checkpg.sh")
@@ -72,7 +72,7 @@ let reactService =
       , image = Some "recipeyak/react:latest"
       , command = Some (Compose.StringOrList.String "sh bootstrap.sh")
       , env_file = Some (Compose.StringOrList.List [ ".env-production" ])
-      , volumes = Some [ "react-static-files:/var/app/dist" ]
+      , volumes = Some [ Compose.ServiceVolume.Short "react-static-files:/var/app/dist" ]
       , logging
       }
 


### PR DESCRIPTION
Little extension (breaks existing configs by introducing a switch between "short" and "long" syntax): Add possibility to configure the "volume" attribute of a service in "long form", i.e. with more specific attribues. It's still possible to use the "short form" of course.