### PR TITLE
Change network types to align with v3 spec

### DIFF
--- a/compose/v3/defaults.dhall
+++ b/compose/v3/defaults.dhall
@@ -13,6 +13,12 @@ let ServiceVolumeLong =
       , tmpfs = None { size : Optional Text }
       }
 
+let ServiceNetwork =
+      { aliases = None (List Text)
+      , ipv4_address = None Text
+      , ipv6_address = None Text
+      }
+
 let Service =
         { deploy = None types.Deploy
         , build = None types.Build
@@ -41,7 +47,7 @@ let Service =
         , logging = None types.Logging
         , mac_address = None Text
         , network_mode = None Text
-        , networks = None types.Networks
+        , networks = None types.ServiceNetworks
         , pid = None Text
         , ports = None (List types.StringOrNumber)
         , privileged = None Bool
@@ -62,6 +68,8 @@ let Service =
         , working_dir = None Text
         }
       : types.Service
+
+let Network = { external = None Bool, name = None Text }
 
 let Volume =
         { driver = None Text
@@ -88,4 +96,11 @@ let ComposeConfig =
         }
       : types.ComposeConfig
 
-in  { ServiceVolumeLong, Service, Volume, ComposeConfig, Healthcheck }
+in  { ServiceVolumeLong
+    , ServiceNetwork
+    , Service
+    , Network
+    , Volume
+    , ComposeConfig
+    , Healthcheck
+    }

--- a/compose/v3/package.dhall
+++ b/compose/v3/package.dhall
@@ -2,13 +2,18 @@ let defaults = ./defaults.dhall
 
 let types = ./types.dhall
 
-in    types
-    ⫽ { ServiceVolumeLong =
-        { Type = types.ServiceVolumeLong, default = defaults.ServiceVolumeLong }
-      , Service = { Type = types.Service, default = defaults.Service }
-      , Volume = { Type = types.Volume, default = defaults.Volume }
-      , Config =
-        { Type = types.ComposeConfig, default = defaults.ComposeConfig }
-      , Healthcheck =
-        { Type = types.Healthcheck, default = defaults.Healthcheck }
-      }
+in      types
+    //  { ServiceVolumeLong =
+          { Type = types.ServiceVolumeLong
+          , default = defaults.ServiceVolumeLong
+          }
+        , ServiceNetwork =
+          { Type = types.ServiceNetwork, default = defaults.ServiceNetwork }
+        , Service = { Type = types.Service, default = defaults.Service }
+        , Network = { Type = types.Network, default = defaults.Network }
+        , Volume = { Type = types.Volume, default = defaults.Volume }
+        , Config =
+          { Type = types.ComposeConfig, default = defaults.ComposeConfig }
+        , Healthcheck =
+          { Type = types.Healthcheck, default = defaults.Healthcheck }
+        }

--- a/compose/v3/types.dhall
+++ b/compose/v3/types.dhall
@@ -45,14 +45,13 @@ let Logging
     : Type
     = { driver : Text, options : Optional Options }
 
+let Network
+    : Type
+    = { external : Optional Bool, name : Optional Text }
+
 let Networks
     : Type
-    = < List : List Text
-      | Map : Map Text { name : Optional Text, external : Optional Bool }
-      | Object :
-          Optional
-            { aliases : List Text, ipv4_address : Text, ipv6_address : Text }
-      >
+    = < List : List Text | Map : Map Text Network >
 
 let Ulimits
     : Type
@@ -99,6 +98,17 @@ let ServiceVolume
     : Type
     = < Short : Text | Long : ServiceVolumeLong >
 
+let ServiceNetwork
+    : Type
+    = { aliases : Optional (List Text)
+      , ipv4_address : Optional Text
+      , ipv6_address : Optional Text
+      }
+
+let ServiceNetworks
+    : Type
+    = < List : List Text | Map : Map Text ServiceNetwork >
+
 let Service
     : Type
     = { deploy : Optional Deploy
@@ -128,7 +138,7 @@ let Service
       , logging : Optional Logging
       , mac_address : Optional Text
       , network_mode : Optional Text
-      , networks : Optional Networks
+      , networks : Optional ServiceNetworks
       , pid : Optional Text
       , ports : Optional (List StringOrNumber)
       , privileged : Optional Bool
@@ -190,6 +200,8 @@ in  { ComposeConfig
     , Service
     , ServiceVolume
     , ServiceVolumeLong
+    , ServiceNetwork
+    , ServiceNetworks
     , StringOrNumber
     , Deploy
     , Build
@@ -198,6 +210,7 @@ in  { ComposeConfig
     , Healthcheck
     , Labels
     , Logging
+    , Network
     , Networks
     , Ulimits
     , Volumes


### PR DESCRIPTION
I apologize if I'm wrong, but as far as I can tell, the usage of network
types didn't match the v3 spec. The `Networks` type seemed to be a
combination of what would be expected in a top-level `networks` block
and what would be expected in a service-level `networks` block.

I've created `Network`, `ServiceNetwork`, and `ServiceNetworks` types
(along with modifying the existing `Networks` type) in an attempt to
align with the spec.

I ran into this because I wanted to assign an `alias` to a service
within a network, and there didn't appear to be a way previously.
